### PR TITLE
Hardware Page Live + Updated

### DIFF
--- a/2022/index.html
+++ b/2022/index.html
@@ -72,8 +72,10 @@
                 </div>
                 <div class="nav-div"><a id="prizes-page-nav" href="#prizes-page" class="secondary-page-link">PRIZES</a>
                 </div>
+                -->
                 <div class="nav-div"><a id="hardware-page-nav" href="#hardware-page" class="secondary-page-link">HARDWARE</a>
                 </div>
+                <!--
                 <div class="nav-div"><a id="mentors-page-nav" href="#mentors-page" class="secondary-page-link">MENTORS</a>
                 </div>
                 <div class="nav-div"><a id="vipjudges-page-nav" href="#vipjudges-page" class="secondary-page-link">VIP JUDGES</a>
@@ -779,16 +781,21 @@
                 <!-- category for biohack hardware -->
                 <hr>
                 <p>
+                    More information will be posted here on how to get access to hardware so check back soon!
+                    <!-- COMMENT ADDED HERE ABOUT THE INFORMATION ON HOW TO GET HARDWARE
                     MakeOHI/O is Virtual! That means this year’s access to hardware is brand new. On <b>February 12th</b> via the
                     Discord platform, challenges will be announced and teams will be given access to a <u>Kit Builder website</u>.
                     Teams will have the weekend to evaluate the challenges, their hardware budget, and select from a list of
                     components to create their hardware kit. That hardware will serve as all the materials used for your MakeOHI/O
                     project.
+                    -->
                     <br><br>
                 </p>
                 <h2 align="left"> Things to know:</h2>
                 <div class="faqText">
                     <ol>
+                        <li>More information coming soon!</li>
+                        <!--
                         <li>Only one kit may be built per team.</li>
                         <li>Challenges to be announced on Feb 12th</li>
                         <li>
@@ -813,43 +820,79 @@
                                     If your entire team lives <b><u>more than 30 miles </u></b> outside of campus shipping arrangements can be made for your hardware by emailing
                                     <a class="pretty-link" href="mailto:woods.768@buckeyemail.osu.edu">woods.768@buckeyemail.osu.edu</a>
                                 </li>
+                                -->
                             </ul>
                         </li>
                     </ol>
                 </div>
                 <hr>
                 <br>
-                Take a look at this years hardware from KitBuilder!:
+                Take a look at this year's hardware!:
 
                 <div class = "hardwarestarterkits1" style="font-size:17px">
+
 
                     <h2 align="left">Starter Kits:</h2>
 
                     <div class="col third" >
                         <div class="media-list" style="font-size:15px">
                             <ul style="list-style: none;">
+                                <li>More information coming soon!</li><br>
+                                <!--
                                 <li>ELEGOO 37 in 1 Modules Kit for Arduino </li><br>
                                 <li>Sunfounder Kit for Arduino UNO </li><br>
                                 <li>Basic Circuit Starter Kit </li>
+                                -->
                             </ul>
                         </div>
+
 
                         <h2 align="left">Controllers:</h2>
                         <div class="media-list" style="font-size:15px">
                             <ul style="list-style: none;">
+
+                                <li>Inland Uno R3 MainBoard (Arduino Compatible)</li><br>
+                                <!--
                                 <li>AIR MODULE CC110L (40) </li><br>
                                 <li>Arduino Uno</li><br>
+                                <li>ESP8266 NodeMCU CP2102 ESP-12E</li>
                                 <li>MSP430 MSP-EXP430G2 (70)</li><br>
                                 <li>MSP430 MSP-EXPF5529LP (69)</li><br>
                                 <li>Raspberry Pi 3</li><br>
                                 <li>Raspberry Pi Zero</li><br>
                                 <li>Teensy</li><br>
+                                -->
                             </ul>
                         </div>
 
                         <h2 align="left">Input:</h2>
                         <div class="media-list" style="font-size:15px">
                             <ul style="list-style: none;">
+                                <li>Avoidance Sensor</li><br>
+                                <li>Axis Analog Gyro Sensors</li><br>
+                                <li>Buttons</li><br>
+                                <li>Big Sound Sensor</li><br>
+                                <li>Arducam Mini Module Camera</li><br>
+                                <li>Digital Temperature Sensor</li><br>
+                                <li>Flame Sensor</li><br>
+                                <li>Joystick</li><br>
+                                <li>IR Receiver</li><br>
+                                <li>Magnetic Spring Sensor</li><br>
+                                <li>Membrane Switch</li><br>
+                                <li>Metal Touch Sensor</li><br>
+                                <li>Rotary Encoder</li><br>
+                                <li>Small Sound Sensor</li><br>
+                                <li>Shock Receiver</li><br>
+                                <li>Tap Module</li><br>
+                                <li>Tilt Switch</li><br>
+                                <li>Temp and Humidity Sensor</li><br>
+                                <li>Tracking Sensor</li><br>
+                                <li>Ultrasonic Sensor</li><br>
+                                <li>Wave Level Sensor</li><br>
+                                <li>18820 TEMP</li><br>
+
+
+                                <!--
                                 <li>Circular Force Sensor</li><br>
                                 <li>IR Sensor</li><br>
                                 <li>Light Sensor</li><br>
@@ -862,6 +905,7 @@
                                 <li>Square Force Sensor</li><br>
                                 <li>Temperature AND Humidity Sensor</li><br>
                                 <li>Temperature Sensor</li>
+                                -->
                             </ul>
                         </div>
                     </div>
@@ -874,6 +918,28 @@
                     <div class="col third" >
                         <div class="media-list" style="font-size:15px">
                             <ul style="list-style: none;">
+                                <li>Active Buzzer</li><br>
+                                <li>DC Motors</li><br>
+                                <li>Linear Hall</li><br>
+                                <li>IR Emission</li><br>
+                                <li>Laser Emit</li><br>
+                                <li>LCD screens</li><br>
+                                <li>SMD RGB</li><br>
+                                <li>Passive Buzzer</li><br>
+                                <li>Photo Interrupter</li><br>
+                                <li>Photo Resistor</li><br>
+                                <li>Servos</li><br>
+                                <li>Small Speakers</li><br>
+                                <li>Two Color LED</li><br>
+                                <li>RGB LED</li><br>
+                                <li>Red LED</li><br>
+                                <li>Yellow LED</li><br>
+                                <li>Blue LED</li><br>
+                                <li>Green LED</li><br>
+                                <li>White LED</li><br>
+                                <li>7 Color Flash LED</li><br>
+
+                                <!--
                                 <li>7 Segment Displays</li><br>
                                 <li>Assorted Single Color LEDs Kit</li><br>
                                 <li>DC Buzzer</li><br>
@@ -882,28 +948,39 @@
                                 <li>Servos</li><br>
                                 <li>Small Speakers</li><br>
                                 <li>Stepper Motors</li><br>
-
+                                -->
                             </ul>
                         </div>
 
                         <h2 align="left">Power:</h2>
                         <div class="media-list" style="font-size:15px">
                             <ul style="list-style: none;">
+                                <li>ELEGOO AC 100V-240V Converter Adapter</li><br>
+                                <li>Power Supply Module</li><br>
+
+                                <!--
                                 <li>9V (Battery)</li><br>
                                 <li>AA (Battery)</li><br>
                                 <li>AAA (Battery)</li><br>
                                 <li>Battery package (AA, AAA, 9V)</li><br>
+                                <li>Power Supply Module</li><br>
+                                -->
                             </ul>
                         </div>
+
 
                         <h2 align="left">Radio Frequency (RF):</h2>
                         <div class="media-list" style="font-size:15px">
                             <ul style="list-style: none;">
+                                <li>More information coming soon!</li><br>
+
+                                <!--
                                 <li>ESP8266</li><br>
                                 <li>Nooelec SDR</li><br>
                                 <li>nRF24L01</li><br>
                                 <li>Pair Walkie Talkies</li><br>
                                 <li>RTL SDR Kit</li>
+                                -->
                             </ul>
                         </div>
                     </div>
@@ -916,6 +993,38 @@
                     <div class="col third" >
                         <div class="media-list" style="font-size:15px">
                             <ul style="list-style: none;">
+                                <li>Breadboard</li><br>
+                                <li>Diode</li><br>
+                                <li>DSD TECH HC-05 (Bluetooth Addition)</li><br>
+                                <li>DS 1307 RTC Module</li><br>
+                                <li>Electrolytic Capacitor 100u</li><br>
+                                <li>Electrolytic Capacitor 10u</li><br>
+                                <li>ESP8266 NodeMCU CP2102 ESP-12E (WiFi Addition) </li><br>
+                                <li>F-M Dupont Wire</li><br>
+                                <li>Passive Buzzer</li><br>
+                                <li>Photoresistor</li><br>
+                                <li>PN2222 BJT</li><br>
+                                <li>Precision Potentiometer</li><br>
+                                <li>Relay</li><br>
+                                <li>Resistor 10R</li><br>
+                                <li>Resistor 100R</li><br>
+                                <li>Resistor 220R</li><br>
+                                <li>Resistor 330R</li><br>
+                                <li>Resistor 1K</li><br>
+                                <li>Resistor 2K</li><br>
+                                <li>Resistor 5.1K</li><br>
+                                <li>Resistor 10K</li><br>
+                                <li>Resistor 100K</li><br>
+                                <li>Resistor 1M</li><br>
+                                <li>Thermistor</li><br>
+                                <li>22pF Ceramic Capacitor</li><br>
+                                <li>104pF Ceramic Capacitor</li><br>
+                                <li>40Pin Header</li><br>
+                                <li>65 Jumper Wire</li><br>
+                                <li>4N35</li><br>
+                                <li>74HC595</li><br>
+
+                                <!--
                                 <li>5V DC Barrel Jacks</li><br>
                                 <li>Dual H-Bridge Motor Driver IC</li><br>
                                 <li>Power Cables</li><br>
@@ -945,6 +1054,7 @@
                                 <li>Ceramic Capacitor 100nF</li><br>
                                 <li>1N4007 Diode</li><br>
                                 <li>PN2222 BJT</li>
+                                -->
                             </ul>
                         </div>
                     </div>


### PR DESCRIPTION
The hardware list is up to date via  "Master Make 2022 Hardware Sheet" as of 1/28/22 at 9:13pm. The page is also live on the MakeOHI/O site. Feel free to change any hardware pieces or items as necessary. I did my best trying to figure what each was from Amazon descriptions/pictures.