### PR TITLE
Add registration deadlines to get hardware

### DIFF
--- a/2022/index.html
+++ b/2022/index.html
@@ -664,6 +664,42 @@
                 <h1>Schedule</h1>
                 <hr>
                 <br>
+                <h2>Hardware Deadlines</h2>
+                <table class="schedule-table">
+                    <tr>
+                        <td style="width: 40%;" class="box-darkgray">
+                            I want...
+                        </td>
+                        <td style="width: 20%;" class="box-darkgray">
+                            Register by
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="box-gray">
+                            ...hardware provided and shipped to me
+                        </td>
+                        <td class="box-gray">
+                            Friday, February 18th
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            ...hardware provided, but not shipped to me
+                        </td>
+                        <td>
+                            Friday, February 25th
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="box-gray">
+                            ...no hardware provided to me
+                        </td>
+                        <td class="box-gray">
+                            Friday, March 4th
+                        </td>
+                    </tr>
+                </table>
+                <br><br>
                 <h2>Saturday, March 5th</h2>
                 <table class="schedule-table">
                     <tr>


### PR DESCRIPTION
Should we also update the hardware page to reference these deadlines?

Schedule page now looks like this:
<img width="720" alt="image" src="https://user-images.githubusercontent.com/29416016/152838837-c70ce83c-da7f-4ac7-865e-fe00a9502fab.png">
